### PR TITLE
Added missing examples for Aspose.Note for .NET.

### DIFF
--- a/Examples/CSharp/CSharp.csproj
+++ b/Examples/CSharp/CSharp.csproj
@@ -36,8 +36,8 @@
     <StartupObject>Aspose.Note.Examples.CSharp.RunExamples</StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aspose.Note, Version=16.11.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aspose.Note.16.11\lib\net4.0\Aspose.Note.dll</HintPath>
+    <Reference Include="Aspose.Note, Version=16.12.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aspose.Note.16.12.0\lib\net4.0\Aspose.Note.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -63,6 +63,13 @@
     <Compile Include="Images\ExtractImages.cs" />
     <Compile Include="Images\GetInformationOfImages.cs" />
     <Compile Include="Loading-and-Saving\CreateDocWithFormattedRichText.cs" />
+    <Compile Include="Loading-and-Saving\SaveDocToOneNoteFormat.cs" />
+    <Compile Include="Loading-and-Saving\SaveDocToOneNoteFormatUsingOnesaveoptions.cs" />
+    <Compile Include="Loading-and-Saving\SaveDocToOneNoteFormatUsingSaveFormat.cs" />
+    <Compile Include="NoteBook\LoadingNotebookFilewithLoadOptions.cs" />
+    <Compile Include="NoteBook\LoadingNotebookInstantly.cs" />
+    <Compile Include="NoteBook\ReadRichText.cs" />
+    <Compile Include="NoteBook\RetrieveDocumentsfromOneNoteNotebook.cs" />
     <Compile Include="NoteBook\SaveNotebookToStream.cs" />
     <Compile Include="NoteBook\LoadFromStream.cs" />
     <Compile Include="NoteBook\WritingPasswordProtectedDoc.cs" />

--- a/Examples/CSharp/Loading-and-Saving/ExtractContent.cs
+++ b/Examples/CSharp/Loading-and-Saving/ExtractContent.cs
@@ -7,9 +7,9 @@ namespace Aspose.Note.Examples.CSharp.Loading_Saving
 {
     public class ExtractContent
     {
+        // ExStart:ExtractContent
         public static void Run()
-        {
-            // ExStart:ExtractContent
+        {            
             // The path to the documents directory.
             string dataDir = RunExamples.GetDataDir_LoadingAndSaving();
 
@@ -30,9 +30,9 @@ namespace Aspose.Note.Examples.CSharp.Loading_Saving
             // Once the visiting is complete, we can retrieve the result of the operation,
             // that in this example, has accumulated in the visitor.
             Console.WriteLine(myConverter.GetText());
-            Console.WriteLine(myConverter.NodeCount);
-            // ExEnd:ExtractContent          
+            Console.WriteLine(myConverter.NodeCount);            
         }
+
         /// <summary>
         /// Simple implementation of saving a document in the plain text format. Implemented as a Visitor.
         /// </summary>
@@ -139,5 +139,6 @@ namespace Aspose.Note.Examples.CSharp.Loading_Saving
             private bool mIsSkipText;
             private Int32 nodecount;
         }
+        // ExEnd:ExtractContent          
     }
 }

--- a/Examples/CSharp/Loading-and-Saving/SaveDocToOneNoteFormat.cs
+++ b/Examples/CSharp/Loading-and-Saving/SaveDocToOneNoteFormat.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Aspose.Note.Examples.CSharp.Loading_Saving
+{
+    class SaveDocToOneNoteFormat
+    {
+        public static void Run()
+        {
+            // ExStart:SaveDocToOneNoteFormat
+            string inputFile = "Sample1.one";
+            string dataDir = RunExamples.GetDataDir_LoadingAndSaving();
+            string outputFile = "SaveDocToOneNoteFormat_out.one";
+            
+            Document doc = new Document(dataDir + inputFile);
+            doc.Save(dataDir + outputFile);
+            // ExEnd:SaveDocToOneNoteFormat
+        }
+    }
+}

--- a/Examples/CSharp/Loading-and-Saving/SaveDocToOneNoteFormatUsingOnesaveoptions.cs
+++ b/Examples/CSharp/Loading-and-Saving/SaveDocToOneNoteFormatUsingOnesaveoptions.cs
@@ -1,0 +1,24 @@
+﻿using Aspose.Note.Saving;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Aspose.Note.Examples.CSharp.Loading_Saving
+{
+    class SaveDocToOneNoteFormatUsingOnesaveoptions
+    {
+        public static void Run()
+        {
+            // ExStart:SaveDocToOneNoteFormatUsingOnesaveoptions
+            string inputFile = "Sample1.one";
+            string dataDir = RunExamples.GetDataDir_LoadingAndSaving();
+            string outputFile = "SaveDocToOneNoteFormatUsingOnesaveoptions_out.one";
+
+            Document document = new Document(dataDir + inputFile);
+
+            document.Save(dataDir + outputFile, new OneSaveOptions());
+            // ExEnd:SaveDocToOneNoteFormatUsingOnesaveoptions
+        }
+    }
+}

--- a/Examples/CSharp/Loading-and-Saving/SaveDocToOneNoteFormatUsingSaveFormat.cs
+++ b/Examples/CSharp/Loading-and-Saving/SaveDocToOneNoteFormatUsingSaveFormat.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Aspose.Note.Examples.CSharp.Loading_Saving
+{
+    class SaveDocToOneNoteFormatUsingSaveFormat
+    {
+        public static void Run()
+        {
+            // ExStart:SaveDocToOneNoteFormatUsingSaveFormat
+            string inputFile = "Sample1.one";
+            string dataDir = RunExamples.GetDataDir_LoadingAndSaving();
+            string outputFile = "SaveDocToOneNoteFormatUsingSaveFormat_out.one";
+
+            Document document = new Document(dataDir + inputFile);
+
+            document.Save(dataDir + outputFile, SaveFormat.One);
+            // ExEnd:SaveDocToOneNoteFormatUsingSaveFormat
+        }
+    }
+}

--- a/Examples/CSharp/NoteBook/LoadingNotebookFilewithLoadOptions.cs
+++ b/Examples/CSharp/NoteBook/LoadingNotebookFilewithLoadOptions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Aspose.Note.Examples.CSharp.NoteBook
+{
+    class LoadingNotebookFilewithLoadOptions
+    {
+        public static void Run()
+        {
+            // ExStart:LoadingNotebookFilewithLoadOptions
+            string inputFile = "notebook.onetoc2";
+            string dataDir = RunExamples.GetDataDir_NoteBook();
+
+            // By default children loading is "lazy".
+            Notebook notebook = new Notebook(dataDir + inputFile);
+
+            foreach (INotebookChildNode notebookChildNode in notebook) {
+	            // Actual loading of the child document happens only here.
+	            if (notebookChildNode is Document) {
+		            // Do something with child document
+	            }
+            }
+            // ExEnd:LoadingNotebookFilewithLoadOptions
+        }
+    }
+}

--- a/Examples/CSharp/NoteBook/LoadingNotebookInstantly.cs
+++ b/Examples/CSharp/NoteBook/LoadingNotebookInstantly.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Aspose.Note.Examples.CSharp.NoteBook
+{
+    class LoadingNotebookInstantly
+    {
+        public static void Run()
+        {
+            // ExStart:LoadingNotebookInstantly
+            // By default children loading is "lazy".
+            // Therefore for instant loading has took place,
+            // it is necessary to set the NotebookLoadOptions.InstantLoading flag.
+            NotebookLoadOptions loadOptions = new NotebookLoadOptions();
+            loadOptions.InstantLoading = true;
+            String inputFile = "notebook.onetoc2";
+            String dataDir = RunExamples.GetDataDir_NoteBook();
+            Notebook notebook = new Notebook(dataDir + inputFile, loadOptions);
+
+            // All child documents are already loaded.
+            foreach (INotebookChildNode notebookChildNode in notebook) {
+	            if (notebookChildNode is Document) {
+		            // Do something with child document
+	            }
+            }
+            // ExEnd:LoadingNotebookInstantly
+        }
+    }
+}

--- a/Examples/CSharp/NoteBook/ReadRichText.cs
+++ b/Examples/CSharp/NoteBook/ReadRichText.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Aspose.Note.Examples.CSharp.NoteBook
+{
+    class ReadRichText
+    {
+        public static void Run()
+        {
+            // ExStart:ReadRichText
+            string inputFile = "notebook.onetoc2";
+            string dataDir = RunExamples.GetDataDir_NoteBook();
+
+            Notebook rootNotebook = new Notebook(dataDir + inputFile);
+
+            IList<RichText> allRichTextNodes = rootNotebook.GetChildNodes<RichText>();
+            foreach (RichText richTextNode in allRichTextNodes) {
+	            Console.WriteLine(richTextNode.Text);
+            }
+            // ExEnd:ReadRichText
+        }
+    }
+}

--- a/Examples/CSharp/NoteBook/RetrieveDocumentsfromOneNoteNotebook.cs
+++ b/Examples/CSharp/NoteBook/RetrieveDocumentsfromOneNoteNotebook.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Aspose.Note.Examples.CSharp.NoteBook
+{
+    class RetrieveDocumentsfromOneNoteNotebook
+    {
+        public static void Run()
+        {
+            // ExStart:RetrieveDocumentsfromOneNoteNotebook
+            string inputFile = "notebook.onetoc2";
+            string dataDir = RunExamples.GetDataDir_NoteBook();
+            Notebook rootNotebook = new Notebook(dataDir + inputFile);
+
+            IList<Document> allDocuments = rootNotebook.GetChildNodes<Document>();
+            foreach (Document document in allDocuments) {
+	            Console.WriteLine(document.DisplayName);
+            }
+            // ExEnd:RetrieveDocumentsfromOneNoteNotebook
+        }
+    }
+}

--- a/Examples/CSharp/RunExamples.cs
+++ b/Examples/CSharp/RunExamples.cs
@@ -14,6 +14,7 @@ using Aspose.Note.Examples.CSharp.Tags;
 using Aspose.Note.Examples.CSharp.Tasks;
 using Aspose.Note.Examples.CSharp.Hyperlinks;
 using Aspose.Note.Examples.CSharp.WorkingWithNoteBook;
+using Aspose.Note.Examples.CSharp.NoteBook;
 
 namespace Aspose.Note.Examples.CSharp
 {
@@ -47,6 +48,9 @@ namespace Aspose.Note.Examples.CSharp
             //CreateDocWithFormattedRichText.Run();
             //ExtractContent.Run();
             //CreateDocWithPageTitle.Run();
+            //SaveDocToOneNoteFormat.Run();
+            //SaveDocToOneNoteFormatUsingOnesaveoptions.Run();
+            //SaveDocToOneNoteFormatUsingSaveFormat.Run();
 
             //// =====================================================
             //// =====================================================
@@ -104,7 +108,7 @@ namespace Aspose.Note.Examples.CSharp
             //ExtractCellText.Run();
             //InsertTable.Run();
             //CreateTableWithLockedColumns.Run();
-            SettingCellBackGroundColor.Run();
+            //SettingCellBackGroundColor.Run();
 
             //// =====================================================
             //// =====================================================
@@ -154,11 +158,15 @@ namespace Aspose.Note.Examples.CSharp
             //ConvertToPDF.Run();
             //CreateNoteBook.Run();
             //RemoveChildNode.Run();
-            CreatingPasswordProtectedDoc.Run();
-            LoadingPasswordProtectedDoc.Run();
-            LoadFromStream.Run();
-            SaveNotebookToStream.Run();
-            WritingPasswordProtectedDoc.Run();
+            //CreatingPasswordProtectedDoc.Run();
+            //LoadingPasswordProtectedDoc.Run();
+            //LoadFromStream.Run();
+            //SaveNotebookToStream.Run();
+            //WritingPasswordProtectedDoc.Run();
+            //LoadingNotebookFilewithLoadOptions.Run();
+            //LoadingNotebookInstantly.Run();
+            //RetrieveDocumentsfromOneNoteNotebook.Run();
+            //ReadRichText.Run();
 
             // Stop before exiting
             Console.WriteLine("\n\nProgram Finished. Press any key to exit....");

--- a/Examples/CSharp/packages.config
+++ b/Examples/CSharp/packages.config
@@ -1,4 +1,2 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Aspose.Note" version="16.11" targetFramework="net40" />
-</packages>
+<packages />


### PR DESCRIPTION
Added below examples,

- Save Doc To One Note Format
- Save Doc To One Note Format Using One save options
- Save Doc To One Note Format Using Save Format
- Loading Notebook File with Load Options
- Loading Notebook Instantly
- Read Rich Text
- Retrieve Documents from One Note Notebook